### PR TITLE
Ensure copilot workflows check out repository

### DIFF
--- a/.github/workflows/copilot-ci-autofix.yml
+++ b/.github/workflows/copilot-ci-autofix.yml
@@ -19,6 +19,8 @@ jobs:
       ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Run Copilot CI auto-fix
         uses: ./.github/actions/copilot-exec
         env:

--- a/.github/workflows/copilot-email-triage.yml
+++ b/.github/workflows/copilot-email-triage.yml
@@ -13,6 +13,8 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Run Copilot email triage
         uses: ./.github/actions/copilot-exec
         env:

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -13,6 +13,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Run Copilot repository audit
         uses: ./.github/actions/copilot-exec
         env:

--- a/.github/workflows/copilot-todo-pr.yml
+++ b/.github/workflows/copilot-todo-pr.yml
@@ -15,6 +15,8 @@ jobs:
     if: github.event.label.name == 'Todo'
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Run Copilot todo automation
         uses: ./.github/actions/copilot-exec
         env:

--- a/.github/workflows/screeps-stats-monitor.yml
+++ b/.github/workflows/screeps-stats-monitor.yml
@@ -13,6 +13,8 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Run Copilot stats monitor
         uses: ./.github/actions/copilot-exec
         env:


### PR DESCRIPTION
## Summary
- add checkout steps before invoking the local copilot-exec composite action in each Copilot workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f7d5dc47b88320b23e459f208cbd65