### PR TITLE
fix: add workflows specification to copilot-ci-autofix workflow_run trigger

### DIFF
--- a/.github/workflows/copilot-ci-autofix.yml
+++ b/.github/workflows/copilot-ci-autofix.yml
@@ -2,6 +2,7 @@ name: Copilot CI AutoFix
 
 on:
   workflow_run:
+    workflows: ["Quality Gate", "Post Merge Release"]
     types:
       - completed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project are documented here. This changelog now main
 
 ### Fixed
 
+- Fixed `copilot-ci-autofix.yml` workflow missing `workflows` specification in `workflow_run` trigger (#69)
+
+### Fixed
+
 - Fixed build error caused by node-gyp attempting to use Python 2 syntax with Python 3
 - Moved `@screeps/common`, `@screeps/driver`, `@screeps/engine`, and `screeps-server-mockup` packages to `optionalDependencies` to allow installation to succeed even when native modules fail to build
 - Added `.npmrc` to configure build behavior for optional dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "screeps-gpt",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "screeps-gpt",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "screeps-api": "^1.16.1",


### PR DESCRIPTION
Fixes #69

## Changes Made

- Added missing `workflows` specification to the `workflow_run` trigger in `.github/workflows/copilot-ci-autofix.yml`
- The workflow now properly specifies it should monitor "Quality Gate" and "Post Merge Release" workflows
- Updated CHANGELOG.md to document the fix

## Validation

- ✅ YAML syntax validated with Python yaml parser
- ✅ Workflow configuration follows GitHub Actions documentation for `workflow_run` events
- ✅ Prevents the workflow from running on all completed workflows (which was invalid)

This fix resolves the invalid workflow configuration that was missing the required `workflows` key for the `workflow_run` trigger.