### PR TITLE
fix: prevent deploy workflow failure when grep returns no matches (run 18702059978)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
             echo "Looking for version tag for commit $SHA"
             
             # First try to find a tag pointing to this exact commit
-            VERSION=$(git tag --points-at "$SHA" | grep -E '^v[0-9]' | head -n 1)
+            VERSION=$(git tag --points-at "$SHA" | grep -E '^v[0-9]' | head -n 1 || true)
             
             # If no tag found on this commit, get the latest version tag
             # This handles the case where the Post Merge Release workflow 


### PR DESCRIPTION
## Issue
The deployment workflow (run 18702059978) was failing because the `git tag --points-at SHA | grep -E '^v[0-9]'` pipeline returns exit code 1 when no matches are found. With GitHub Actions' `set -e -o pipefail` options, this caused the entire step to fail before the fallback logic could execute.

## Root Cause
When `grep` finds no matches, it returns exit code 1. Combined with `pipefail`, this propagates through the pipeline and terminates the script with exit code 1, preventing the fallback logic that would use the latest available version tag.

## Solution
Added `|| true` to the grep pipeline to prevent it from failing when no version tags are found on the specific commit, allowing the existing fallback logic to use the latest available tag (`v0.1.5`).

## Testing
Verified the fix works by simulating the exact failing scenario with `set -e -o pipefail` enabled.

Fixes workflow run: https://github.com/ralphschuler/.screeps-gpt/actions/runs/18702059978