### PR TITLE
fix: resolve Marked.js renderer compatibility issue for docs build

### DIFF
--- a/scripts/build-docs-site.ts
+++ b/scripts/build-docs-site.ts
@@ -21,16 +21,22 @@ interface VersionEntry {
   readonly slug: string;
 }
 
-const renderer = new marked.Renderer();
-const originalLink = renderer.link.bind(renderer);
-renderer.link = (href, title, text) => {
-  let nextHref = typeof href === "string" ? href : "";
-  if (nextHref.endsWith(".md")) {
-    nextHref = nextHref.replace(/\.md(#[^#]+)?$/, (_, anchor) => `.html${anchor ?? ""}`);
-  }
-  return originalLink(nextHref, title, text);
-};
-marked.use({ renderer, mangle: false, headerIds: true });
+marked.use({
+  renderer: {
+    link(href, title, text) {
+      let nextHref = typeof href === "string" ? href : "";
+      if (nextHref.endsWith(".md")) {
+        nextHref = nextHref.replace(/\.md(#[^#]+)?$/, (_, anchor) => `.html${anchor ?? ""}`);
+      }
+      
+      // Use the default link renderer with modified href
+      const titleAttr = title ? ` title="${title}"` : '';
+      return `<a href="${nextHref}"${titleAttr}>${text}</a>`;
+    }
+  },
+  mangle: false, 
+  headerIds: true 
+});
 
 async function ensureEmptyDir(directory: string): Promise<void> {
   await rm(directory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Fixes the failing documentation site build (run 18709562479) by resolving Marked.js v16 compatibility issues.

## Root Cause
The error 'Cannot read properties of undefined (reading parseInline)' was caused by using the deprecated renderer override pattern with Marked v16. The renderer methods are called with a different `this` context in v16.

## Fix
- Replaced the deprecated `renderer.link` override with the extension pattern
- Updated to use Marked v16 compatible renderer syntax
- Maintained the same functionality of converting .md links to .html

## Validation
- Addressed the specific TypeError from the workflow logs
- Uses the recommended Marked v16 extension approach
- Preserves existing link transformation behavior

## Related
- Fixes workflow run: https://github.com/ralphschuler/.screeps-gpt/actions/runs/18709562479
- Resolves "Publish Documentation Site" CI failure