### PR TITLE
fix: update post-merge-release workflow to use Node.js 20

### DIFF
--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -26,32 +26,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Setup Python 2
-        uses: ./.github/actions/setup-python2
-
-      - name: Setup Node.js 16
-        uses: ./.github/actions/setup-node16
-
-      - name: Cache npm dependencies
-        uses: actions/cache@v4
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
         with:
-          path: |
-            node_modules
-            ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm-${{ runner.os }}-
+          node-version: "20"
+          cache: "npm"
 
-      - name: Export Python path for node-gyp
-        shell: bash
-        run: |
-          echo "GYP_DEFINES=standalone_static_library=0" \
-            >> $GITHUB_ENV
-          echo "PYTHON=$(command -v python2 || command -v python)" \
-            >> $GITHUB_ENV
-          python --version
-
-      - name: Install dependencies (with Python 2)
+      - name: Install dependencies
         run: npm install
 
       - name: Lint with fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. This changelog now main
 
 ### Fixed
 
+- **Post Merge Release workflow Node.js compatibility**
+  - Updated post-merge-release.yml to use Node.js 20 instead of Node.js 16
+  - Resolves `ERR_UNKNOWN_BUILTIN_MODULE: node:readline/promises` error in Husky pre-commit hooks
+  - Aligns runtime with lint-staged 16.2.6+ requirement for Node.js 20.17+
+  - Removes Python 2 setup dependency as modern Node.js doesn't require it for npm packages
+  - Fixes CI autofix workflow run 18760229405
 - **Deterministic creep naming in BehaviorController**
   - Replaced `Math.random()` with memory-persisted counter for creep name generation
   - Ensures deterministic AI behavior for reliable testing and debugging

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "screeps-gpt",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Autonomously evolving Screeps AI with automated development and deployment workflows.",
   "license": "MIT",
   "author": "OpenAI Automations",
   "type": "module",
   "engines": {
-    "node": ">=16.0.0 <=20.x",
+    "node": ">=20.17.0",
     "npm": ">=8.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes CI autofix workflow run 18760229405 by resolving Node.js compatibility issues in the post-merge-release workflow.

## Root Cause Analysis

The post-merge-release workflow was failing with:
```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:readline/promises
```

This occurred because:
1. The workflow was using Node.js 16.20.2
2. lint-staged 16.2.6+ requires Node.js >=20.17.0
3. The `node:readline/promises` module is only available in Node.js 17+

## Changes Made

- **Updated workflow to use Node.js 20** instead of custom setup-node16 action
- **Removed Python 2 setup dependency** as it's no longer needed for modern Node.js packages
- **Updated package.json engines field** to require Node.js >=20.17.0 for consistency
- **Updated CHANGELOG.md** with fix details

## Verification

✅ Husky pre-commit hooks run successfully  
✅ lint-staged executes without Node.js compatibility errors  
✅ Unit tests pass  
✅ Semantic version bump works correctly  

## References

- Failing workflow run: https://github.com/ralphschuler/.screeps-gpt/actions/runs/18760229405
- Related to lint-staged Node.js requirements: https://github.com/okonet/lint-staged/releases