### PR TITLE
fix: exclude optional dependencies from docs build (fixes run 18762715992)

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           bun-version: 1.3.1
       - name: Install dependencies
-        run: bun install --production
+        run: bun install --production --omit=optional
       - name: Generate documentation site
         run: |
           bun run versions:update


### PR DESCRIPTION
The docs build was failing because `isolated-vm` from `@screeps/driver` requires Python 2 syntax but CI has Python 3. Using `--omit=optional` prevents installing optionalDependencies that aren't needed for docs.

This fixes workflow run #18762715992.

## Verification

- [x] Build runs successfully without installing `isolated-vm`
- [x] Documentation site is generated correctly  
- [x] Unit tests pass