### PR TITLE
fix(ci): use npm ci instead of bun install to skip optional dependencies reliably

### DIFF
--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: 1.3.1
 
       - name: Install dependencies
-        run: bun install --no-optional
+        run: npm ci --omit=optional
 
       - name: Lint with fixes
         run: bun run lint:fix


### PR DESCRIPTION
**Fixes workflow run 18763029915** where isolated-vm optional dependency was causing Python syntax errors during post-merge release workflow.

## Root Cause
- The workflow uses `bun install --no-optional` but Bun still processes optional dependencies
- `isolated-vm` (optional dependency from `@screeps/driver`) requires Python 2 syntax but CI has Python 3
- This caused gyp build failures with Python syntax errors

## Solution  
- Changed from `bun install --no-optional` to `npm ci --omit=optional`
- npm handles optional dependency exclusion more reliably than bun
- `isolated-vm` is only needed for mockup tests, not production builds
- Maintains all required dev dependencies for lint, format, and versioning

## Verification
- ✅ `npm ci --omit=optional` installs without `isolated-vm` errors  
- ✅ `eslint --fix` and `prettier --write` work correctly
- ✅ All unit tests pass via lint-staged hooks
- ✅ Required dev dependencies (tsx, eslint, prettier) are available

This fix directly addresses the specific failure in run 18763029915 while following repository automation guidelines.