### PR TITLE
fix: remove duplicate dependencies causing docs build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented here. This changelog now main
 
 ## [Unreleased]
 
+### Fixed
+
+- **Documentation Site Build Failure**: Fixed duplicate dependencies in package.json causing lockfile conflicts in CI
+  - Removed duplicate `tsx` and `marked` entries from dependencies section (keeping them in devDependencies)
+  - Updated bun.lock to reflect proper dependency resolution
+  - Fixes run ID: 18777257201
+
 ### Added
 
 - **Daily Autonomous Bot Monitoring workflow**

--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,9 @@
     "": {
       "name": "screeps-gpt",
       "dependencies": {
-        "marked": "^16.4.1",
         "node-fetch": "^3.3.2",
         "screeps-api": "^1.16.1",
         "semver": "^7.7.3",
-        "tsx": "^4.20.6",
         "zod": "^4.1.12",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,7 @@
     "node-fetch": "^3.3.2",
     "screeps-api": "^1.16.1",
     "semver": "^7.7.3",
-    "zod": "^4.1.12",
-    "tsx": "^4.20.6",
-    "marked": "^16.4.1"
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/node": "^24.9.1",


### PR DESCRIPTION
Resolves lockfile conflicts by removing duplicate tsx and marked dependencies from dependencies section, keeping them only in devDependencies where they belong.

**Root Cause**: The `package.json` file contained duplicate entries for `tsx` and `marked` packages in both the `dependencies` and `devDependencies` sections. This caused bun install to fail with a lockfile frozen error during the documentation site build in CI.

**Fix Applied**: 
- Removed duplicate `tsx` and `marked` entries from the `dependencies` section 
- Kept them only in `devDependencies` where they belong (as build tools)
- Regenerated bun.lock to reflect proper dependency resolution

**Validation**:
- ✅ `bun install --production` now succeeds
- ✅ `bun run build:docs-site` builds successfully  
- ✅ `bun run lint` passes (only pre-existing warnings)

Fixes run ID: 18777257201