### PR TITLE
fix(docs): remove --production flag from docs build to include devDependencies

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           bun-version: 1.3.1
       - name: Install dependencies
-        run: bun install --production
+        run: bun install
       - name: Generate documentation site
         run: |
           bun run versions:update


### PR DESCRIPTION
The docs workflow requires tsx and other build tools from devDependencies.
The --production flag was preventing husky and tsx from being installed,
causing the build to fail when prepare script ran.

**Root Cause Analysis:**
- Workflow was using `bun install --production` which excludes devDependencies
- The `prepare` script runs `husky` which is only in devDependencies  
- `bun run build:docs-site` requires `tsx` which is also in devDependencies
- This caused `husky: command not found` error during install

**Fix Applied:**
- Removed `--production` flag from `bun install` command
- Verified build works with full dependencies installed

**Validation:**
- ✅ Local build test passed
- ✅ All required devDependencies available  
- ✅ Documentation site generates successfully

Fixes run ID: 18778720697