### PR TITLE
fix(spawn-monitor): correct terrain API method call (run 18779690172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. This changelog now main
 
 ### Fixed
 
+- **Screeps Spawn Monitor API Failure**: Fixed terrain API method call in autospawn script
+  - Use correct `api.raw.game.roomTerrain(roomName, 1)` instead of invalid `api.raw.game["room-terrain"]({ room, shard })`
+  - Removed unused shard parsing logic that was unnecessary for working API call
+  - Fixes "api.raw.game.room-terrain is not a function" error
+  - Fixes run ID: 18779690172
 - **Screeps Spawn Monitor API Failure**: Fixed incorrect API call for room terrain on sharded servers
   - Fixed screeps-api call to use correct room-terrain endpoint with proper shard parameter
   - Parse shard from room name format (shard3/E45S25) instead of passing invalid parameters

--- a/scripts/screeps-autospawn.ts
+++ b/scripts/screeps-autospawn.ts
@@ -244,10 +244,8 @@ async function checkAndRespawn(): Promise<void> {
 
         // Get terrain
         console.log("  Analyzing terrain...");
-        // Parse shard and room from roomName format "shard3/E45S25"
-        const [shard, room] = roomName.includes("/") ? roomName.split("/") : ["shard3", roomName];
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const terrainResult = (await (api as any).raw.game["room-terrain"]({ room, shard })) as RoomTerrainResponse;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable
+        const terrainResult = (await api.raw.game.roomTerrain(roomName, 1)) as RoomTerrainResponse;
 
         if (!terrainResult.ok || !terrainResult.terrain || terrainResult.terrain.length === 0) {
           throw new Error("Failed to get room terrain");


### PR DESCRIPTION
Fixes the Screeps Spawn Monitor workflow failure by correcting the terrain API method call.

**Root Cause**: Invalid api.raw.game room-terrain method was causing function not found error.

**Fix**: Use correct api.raw.game.roomTerrain method consistent with existing working code.

**Validation**: Linting passes, build succeeds, tests pass.

Fixes run ID: 18779690172