### PR TITLE
Fix missing closing brace in Hexo build script (Run 18781467139)

### DIFF
--- a/scripts/build-hexo-site.ts
+++ b/scripts/build-hexo-site.ts
@@ -49,6 +49,7 @@ async function buildHexoSite(): Promise<void> {
         } else {
           console.warn(`⚠ Failed to load ${pluginName}:`, err);
         }
+      }
     }
 
     // Clean up global


### PR DESCRIPTION
## Summary

Fixes syntax error in `scripts/build-hexo-site.ts` that prevented documentation site build.

## Root Cause

Missing closing brace in the plugin loading loop at line 52, causing the outer try-catch block structure to be malformed.

## Changes

- Add missing closing brace for the catch block in the plugin loading loop
- Resolves esbuild transformation error preventing Hexo site generation
- Enables successful documentation site build and GitHub Pages deployment

## Validation

✅ Build script now executes successfully  
✅ Documentation site generates without errors  
✅ All linting and formatting checks pass  
✅ Unit tests continue to pass  

Fixes run ID: **18781467139**