### PR TITLE
Fix TypeScript lint violations in automation scripts and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. This changelog now main
 
 ### Fixed
 
+- **TypeScript lint compliance**: Removed unsafe `any` usage in automation scripts and tests
+  - Added a typed Screeps raw API wrapper and stricter spawn placement flow in `scripts/screeps-autospawn.ts`
+  - Declared a typed global Hexo reference for plugin loading and tightened test doubles to avoid unbound methods
+  - Hardened mockup integration tests and helpers to dynamically import `screeps-server-mockup` without `any` casts
 - **Hexo Documentation Build**: Fixed markdown renderer loading in Hexo build script
   - Added proper plugin loading mechanism using global hexo variable for hexo-renderer-marked
   - Ensures markdown files are rendered to HTML instead of staying as .md files

--- a/scripts/build-hexo-site.ts
+++ b/scripts/build-hexo-site.ts
@@ -3,6 +3,11 @@ import { resolve } from "node:path";
 import { cp, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 
+declare global {
+  // The Hexo plugin system expects a global `hexo` reference during initialization.
+  var hexo: Hexo | undefined;
+}
+
 const require = createRequire(import.meta.url);
 
 async function buildHexoSite(): Promise<void> {
@@ -26,8 +31,7 @@ async function buildHexoSite(): Promise<void> {
     console.log("Ensuring renderers are loaded...");
 
     // Set global hexo variable that plugins expect
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (global as any).hexo = hexo;
+    globalThis.hexo = hexo;
 
     const plugins = [
       "hexo-renderer-ejs",
@@ -53,8 +57,7 @@ async function buildHexoSite(): Promise<void> {
     }
 
     // Clean up global
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    delete (global as any).hexo;
+    delete globalThis.hexo;
 
     // Debug info
     console.log("\nConfiguration:");

--- a/tests/e2e/kernelLoop.test.ts
+++ b/tests/e2e/kernelLoop.test.ts
@@ -35,10 +35,11 @@ describe(`Kernel (${TEST_REALM})`, () => {
       getUsedCapacity: vi.fn(() => 0)
     };
 
+    const spawnCreepMock = vi.fn(() => OK);
     const spawn = {
       name: "Spawn1",
       spawning: null,
-      spawnCreep: vi.fn(() => OK),
+      spawnCreep: spawnCreepMock,
       store: spawnStore,
       room: { controller, find: () => [] } as RoomLike
     } as unknown as StructureSpawn;
@@ -78,8 +79,6 @@ describe(`Kernel (${TEST_REALM})`, () => {
     kernel.run(game, memory);
     cpuReadings.value = 5;
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const spawnCreepMock = spawn.spawnCreep as unknown as ReturnType<typeof vi.fn>;
     expect(spawnCreepMock).toHaveBeenCalled();
     expect(memory.systemReport?.report.summary).toBeDefined();
   });

--- a/tests/e2e/respawnScenario.test.ts
+++ b/tests/e2e/respawnScenario.test.ts
@@ -53,10 +53,11 @@ describe(`Respawn Scenario (${TEST_REALM})`, () => {
     const source = { id: "source" } as Source;
     const controller = { id: "controller" } as StructureController;
 
+    const spawnCreepMock = vi.fn(() => OK);
     const spawn = {
       name: "Spawn1",
       spawning: null,
-      spawnCreep: vi.fn(() => OK),
+      spawnCreep: spawnCreepMock,
       store: {
         getFreeCapacity: vi.fn(() => 300),
         getUsedCapacity: vi.fn(() => 0)
@@ -101,8 +102,6 @@ describe(`Respawn Scenario (${TEST_REALM})`, () => {
     expect(memory.respawn?.needsRespawn).toBe(false);
 
     // Verify spawn was attempted
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const spawnCreepMock = spawn.spawnCreep as unknown as ReturnType<typeof vi.fn>;
     expect(spawnCreepMock).toHaveBeenCalled();
   });
 
@@ -120,10 +119,11 @@ describe(`Respawn Scenario (${TEST_REALM})`, () => {
     } as Memory;
 
     // Game state now has a spawn (player respawned)
+    const spawnCreepMock = vi.fn(() => OK);
     const spawn = {
       name: "Spawn1",
       spawning: null,
-      spawnCreep: vi.fn(() => OK),
+      spawnCreep: spawnCreepMock,
       store: {
         getFreeCapacity: vi.fn(() => 300),
         getUsedCapacity: vi.fn(() => 0)

--- a/tests/mockup/setup.ts
+++ b/tests/mockup/setup.ts
@@ -1,16 +1,60 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import type { ScreepsServer, TerrainMatrix } from "screeps-server-mockup";
+export interface MockupBot {
+  memory: Promise<Record<string, unknown>>;
+}
+
+export interface MockupServerWorld {
+  reset(): Promise<void>;
+  stubWorld(): Promise<void>;
+  addBot(options: {
+    username: string;
+    room: string;
+    x: number;
+    y: number;
+    modules: Record<string, string>;
+  }): Promise<MockupBot>;
+  addRoom(roomName: string): Promise<void>;
+  addRoomObject(roomName: string, type: string, x: number, y: number, details: Record<string, unknown>): Promise<void>;
+  readonly gameTime: Promise<number>;
+}
+
+export interface MockupServerInstance {
+  world: MockupServerWorld;
+  start(): Promise<void>;
+  tick(): Promise<void>;
+  stop(): void;
+}
+
+export type MockupTerrainMatrix = Record<string, unknown>;
+
+interface ScreepsServerMockupModule {
+  ScreepsServer: new () => MockupServerInstance;
+  TerrainMatrix: new () => MockupTerrainMatrix;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isMockupModule(value: unknown): value is ScreepsServerMockupModule {
+  return isRecord(value) && typeof value.ScreepsServer === "function" && typeof value.TerrainMatrix === "function";
+}
+
+async function loadMockupModule(): Promise<ScreepsServerMockupModule> {
+  const module: unknown = await import("screeps-server-mockup");
+  if (!isMockupModule(module)) {
+    throw new Error("screeps-server-mockup module does not expose expected exports");
+  }
+  return module;
+}
 
 /**
  * Creates and initializes a Screeps server instance for testing with mockup.
- * @returns A configured ScreepsServer instance with a stubbed world.
+ * @returns A configured mockup server instance with a stubbed world.
  */
-export async function createTestServer(): Promise<ScreepsServer> {
+export async function createTestServer(): Promise<MockupServerInstance> {
   // Dynamic import to handle cases where isolated-vm isn't available
-  const { ScreepsServer: Server } = await import("screeps-server-mockup");
-  const server = new Server() as ScreepsServer;
+  const mockupModule = await loadMockupModule();
+  const server = new mockupModule.ScreepsServer();
   await server.world.reset();
   await server.world.stubWorld();
   return server;
@@ -31,16 +75,16 @@ export function createBotModule(code: string): Record<string, string> {
  * Helper to create a test terrain matrix.
  * @returns A new TerrainMatrix instance.
  */
-export async function createTerrain(): Promise<TerrainMatrix> {
-  const { TerrainMatrix: Matrix } = await import("screeps-server-mockup");
-  return new Matrix() as TerrainMatrix;
+export async function createTerrain(): Promise<MockupTerrainMatrix> {
+  const mockupModule = await loadMockupModule();
+  return new mockupModule.TerrainMatrix();
 }
 
 /**
  * Cleanup helper to properly stop the server.
  * @param server - The server instance to stop.
  */
-export function cleanupServer(server: ScreepsServer): void {
+export function cleanupServer(server: MockupServerInstance): void {
   try {
     server.stop();
   } catch {


### PR DESCRIPTION
## Summary
- add typed guards for Screeps raw API usage and remove unsafe globals in automation scripts
- tighten vitest doubles and mockup utilities to avoid `any` and unbound method issues during linting
- document the lint cleanup in the changelog and refresh the generated versions index

## Testing
- bun run lint
- vitest run --dir tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68fba11569a0832089e31555bcdc89d6