### PR TITLE
fix(ci): exclude workflow files from prettier to prevent permission errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ node_modules/
 
 # Hexo scaffolds use {{ }} template syntax that Prettier breaks
 docs-build/scaffolds/
+
+# GitHub workflows need workflows:write permission to modify
+.github/workflows/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project are documented here. This changelog now main
 
 ### Fixed
 
-- **Post Merge Release workflow permission error (run #18794121870)**
-  - Added `workflows: write` permission to post-merge-release.yml
-  - Resolves GitHub rejection when pushing commits that include workflow file modifications
-  - Enables automated releases when workflow files are updated in the same push
+- **Post Merge Release workflow permission error (run #18794330724)**
+  - Excluded workflow files from prettier formatting in .prettierignore
+  - Resolves GitHub rejection when pushing commits after workflows:write permission was removed
+  - Prevents workflow file modifications during automated release process
+  - Maintains security by avoiding workflows:write permission requirement
 - **TypeScript type safety violations in fetch-screeps-stats test (run #18793984308)**
   - Removed unnecessary eslint-disable comments that weren't effective
   - Added proper TypeScript types to vitest mocks using `ReturnType<typeof vi.fn>`


### PR DESCRIPTION
## Summary

Fixes the post-merge-release workflow failure that occurred in run #18794330724.

## Root Cause

The workflow failed when trying to push commits that included modifications to .github/workflows/copilot-email-triage.yml. GitHub rejected the push because:
- The post-merge-release workflow only has contents: write permission  
- The repository owner intentionally removed workflows: write permission in commit 91fdcab26be5550fa32f46b5bbfec645ca647cb3
- Prettier was formatting workflow files during the release process
- GitHub requires workflows: write permission to push changes to workflow files

## Solution

- Added .github/workflows/ to .prettierignore to exclude workflow files from automatic formatting
- Maintains security by avoiding the need for workflows: write permission
- Prevents workflow file modifications during automated release processes  
- Preserves manual workflow editing while preventing accidental formatting changes

## Validation

- ✅ Verified prettier now ignores workflow files when running bun run format:write
- ✅ All unit tests pass
- ✅ Lint-staged correctly excludes workflow files from formatting
- ✅ CHANGELOG.md updated with proper run ID reference

## Fixes

https://github.com/ralphschuler/.screeps-gpt/actions/runs/18794330724