### PR TITLE
fix(ci): add actions:write permission to post-merge-release workflow

### DIFF
--- a/.github/workflows/copilot-email-triage.yml
+++ b/.github/workflows/copilot-email-triage.yml
@@ -5,19 +5,19 @@ on:
   workflow_dispatch:
     inputs:
       from:
-        description: 'Sender email address'
+        description: "Sender email address"
         required: true
         type: string
       to:
-        description: 'Recipient email address'
+        description: "Recipient email address"
         required: true
         type: string
       subject:
-        description: 'Email subject'
+        description: "Email subject"
         required: true
         type: string
       body:
-        description: 'Email body'
+        description: "Email body"
         required: true
         type: string
 

--- a/.github/workflows/post-merge-release.yml
+++ b/.github/workflows/post-merge-release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
Fixes workflow failure where formatter changes to workflow files require actions:write permission to commit successfully.

**Root Cause**: The post-merge-release workflow (run 18794427739) failed because:
1. The formatter changed single quotes to double quotes in .github/workflows/copilot-email-triage.yml
2. When git-auto-commit tried to commit these changes, GitHub rejected it because the workflow only had contents:write permission
3. Modifying workflow files requires actions:write permission

**Solution**: Added actions:write permission to the post-merge-release workflow.

**Validation**: All unit tests pass.

Resolves run: 18794427739