### PR TITLE
Add codex-exec composite action

### DIFF
--- a/.github/actions/codex-exec/action.yml
+++ b/.github/actions/codex-exec/action.yml
@@ -1,0 +1,229 @@
+name: codex-exec
+description: |
+  Run OpenAI Codex via codex-action with a rendered prompt template and optional caching.
+
+author: "ralph@nyphon.de"
+inputs:
+  prompt-path:
+    description: Path to the prompt template file
+    required: true
+  working-directory:
+    description: Directory to run the Codex command in
+    required: false
+    default: ""
+  output-path:
+    description: File path (relative to working-directory) to store Codex output
+    required: false
+    default: codex-output.txt
+  extra-args:
+    description: Additional arguments to append to the Codex CLI invocation
+    required: false
+    default: ""
+  additional-mcp-config:
+    description: Maintained for drop-in compatibility (unused)
+    required: false
+    default: ""
+  allow-all-paths:
+    description: Whether to allow Codex access to the full filesystem (maps to sandbox "danger-full-access")
+    required: false
+    default: "true"
+  model:
+    description: Optional model identifier to pass to Codex. If empty, Codex defaults are used.
+    required: false
+    default: ""
+  codex-token:
+    description: API key used by Codex. Typically map this to OPENAI_API_KEY.
+    required: false
+    default: ""
+  timeout:
+    description: Maintained for drop-in compatibility (unused)
+    required: false
+    default: "30"
+  verbose:
+    description: Enable verbose logging for debugging (true/false, default false)
+    required: false
+    default: "false"
+  force-response:
+    description: Skip cache restoration to force fresh Codex execution (true/false, default false)
+    required: false
+    default: "false"
+
+outputs:
+  output-path:
+    description: Absolute path to the Codex output file
+    value: ${{ steps.cached.outputs.output-path || steps.finalize.outputs.output-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect checkout status
+      id: detect-checkout
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -d .git ]; then
+          echo "need-checkout=false" >> "$GITHUB_OUTPUT"
+          echo "✅ Repository already present, skipping checkout"
+        else
+          echo "need-checkout=true" >> "$GITHUB_OUTPUT"
+          echo "🔄 Repository not present, will perform checkout"
+        fi
+
+    - name: Conditional checkout
+      if: steps.detect-checkout.outputs.need-checkout == 'true'
+      uses: actions/checkout@v4
+
+    - name: Render prompt
+      id: render
+      if: cancelled() == false
+      shell: bash
+      env:
+        PROMPT_TEMPLATE: ${{ inputs.prompt-path }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set -euo pipefail
+        start_time=$(date +%s)
+
+        if [ "$VERBOSE" = "true" ]; then
+          echo "🔍 Rendering prompt template: $PROMPT_TEMPLATE"
+        fi
+
+        rendered="$(mktemp)"
+        envsubst < "$PROMPT_TEMPLATE" > "$rendered"
+        prompt_sha=$(sha256sum "$rendered" | awk '{print $1}')
+
+        echo "prompt-file=$rendered" >> "$GITHUB_OUTPUT"
+        echo "prompt-sha=$prompt_sha" >> "$GITHUB_OUTPUT"
+
+        if [ "$VERBOSE" = "true" ]; then
+          end_time=$(date +%s)
+          elapsed=$((end_time - start_time))
+          rendered_size=$(wc -c < "$rendered")
+          echo "✅ Prompt rendered in ${elapsed}s (size: ${rendered_size} bytes, sha256: $prompt_sha)"
+        fi
+
+    - name: Resolve output path
+      id: resolve-output
+      shell: bash
+      env:
+        WORKDIR: ${{ inputs.working-directory != '' && inputs.working-directory || github.workspace }}
+        RAW_OUTPUT_PATH: ${{ inputs.output-path }}
+      run: |
+        set -euo pipefail
+        out="${RAW_OUTPUT_PATH:-codex-output.txt}"
+        if [ "${out:0:1}" != "/" ]; then
+          out="$WORKDIR/$out"
+        fi
+        mkdir -p "$WORKDIR" "$(dirname "$out")"
+        echo "path=$out" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve model configuration
+      id: resolve-model
+      shell: bash
+      env:
+        REQUESTED_MODEL: ${{ inputs.model }}
+        CODEX_MODEL: ${{ env.CODEX_MODEL }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set -euo pipefail
+
+        model=""
+
+        if [ -n "${REQUESTED_MODEL:-}" ]; then
+          model="$REQUESTED_MODEL"
+          echo "ℹ️  Using model from input parameter: $model"
+        elif [ -n "${CODEX_MODEL:-}" ]; then
+          model="$CODEX_MODEL"
+          echo "ℹ️  Using model from CODEX_MODEL environment variable: $model"
+        else
+          echo "ℹ️  No model specified, will use Codex defaults"
+        fi
+
+        echo "model=$model" >> "$GITHUB_OUTPUT"
+
+        if [ "$VERBOSE" = "true" ]; then
+          echo "✅ Resolved Codex model: ${model:-<empty>}"
+          echo "   - Input parameter: ${REQUESTED_MODEL:-<empty>}"
+          echo "   - CODEX_MODEL env: ${CODEX_MODEL:-<empty>}"
+          echo "   - Final selection: ${model:-<empty>}"
+        fi
+
+    - name: Restore result cache
+      if: inputs.force-response != 'true'
+      id: cache-result
+      uses: actions/cache@v4
+      with:
+        path: .codex-cache/output.txt
+        key: codex-result-${{ steps.render.outputs.prompt-sha }}-${{ steps.resolve-model.outputs.model }}-${{ runner.os }}
+
+    - name: Log cache status
+      if: inputs.verbose == 'true'
+      shell: bash
+      env:
+        CACHE_HIT: ${{ steps.cache-result.outputs.cache-hit }}
+        PROMPT_SHA: ${{ steps.render.outputs.prompt-sha }}
+        RESOLVED_MODEL: ${{ steps.resolve-model.outputs.model }}
+      run: |
+        if [ "$CACHE_HIT" = "true" ]; then
+          echo "✅ Cache hit for prompt sha256: $PROMPT_SHA (model: $RESOLVED_MODEL)"
+        else
+          echo "🔄 Cache miss - will execute Codex (prompt sha256: $PROMPT_SHA, model: $RESOLVED_MODEL)"
+        fi
+
+    - name: Short-circuit if cached
+      if: steps.cache-result.outputs.cache-hit == 'true'
+      id: cached
+      shell: bash
+      env:
+        OUTPUT_PATH: ${{ steps.resolve-output.outputs.path }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$(dirname "$OUTPUT_PATH")"
+        cp .codex-cache/output.txt "$OUTPUT_PATH"
+        echo "output-path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
+
+        if [ "$VERBOSE" = "true" ]; then
+          cached_size=$(wc -c < "$OUTPUT_PATH")
+          echo "✅ Reused cached Codex output (size: ${cached_size} bytes, path: $OUTPUT_PATH)"
+        else
+          echo "✅ Reused cached Codex output"
+        fi
+
+    - name: Run Codex exec
+      if: steps.cache-result.outputs.cache-hit != 'true'
+      uses: openai/codex-action@v1
+      with:
+        prompt-file: ${{ steps.render.outputs.prompt-file }}
+        output-file: ${{ steps.resolve-output.outputs.path }}
+        working-directory: ${{ inputs.working-directory != '' && inputs.working-directory || github.workspace }}
+        codex-args: ${{ inputs.extra-args }}
+        model: ${{ steps.resolve-model.outputs.model }}
+        openai-api-key: ${{ inputs.codex-token }}
+        sandbox: ${{ inputs.allow-all-paths == 'true' && 'danger-full-access' || 'workspace-write' }}
+        allow-bots: "true"
+
+    - name: Finalize Codex output
+      if: steps.cache-result.outputs.cache-hit != 'true'
+      id: finalize
+      shell: bash
+      env:
+        OUTPUT_PATH: ${{ steps.resolve-output.outputs.path }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "$OUTPUT_PATH" ]; then
+          echo "❌ Codex output file not found at $OUTPUT_PATH" >&2
+          exit 1
+        fi
+        mkdir -p .codex-cache
+        cp "$OUTPUT_PATH" .codex-cache/output.txt
+        echo "output-path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
+
+        if [ "$VERBOSE" = "true" ]; then
+          output_size=$(wc -c < "$OUTPUT_PATH")
+          echo "✅ Codex exec finished successfully"
+          echo "   Output size: ${output_size} bytes"
+        else
+          echo "✅ Codex exec finished"
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. This changelog now main
 
 ### Added
 
+- **Codex composite action for automation workflows**
+  - Added `.github/actions/codex-exec` as a drop-in replacement for `copilot-exec`
+  - Wraps the official `openai/codex-action@v1` with repository-specific caching and prompt rendering
+  - Maintains existing inputs/outputs while renaming the token parameter to `codex-token` for clarity
+
 - **CPU timeout incident tracking documentation**
   - Created centralized incident tracking document in `docs/operations/cpu-timeout-incidents.md`
   - Documents systematic CPU timeout pattern on shard3 (6 incidents spanning 2025-10-26 to 2025-10-27)


### PR DESCRIPTION
## Summary
- add a codex-exec composite action that reuses the existing prompt rendering and caching flow while calling openai/codex-action@v1
- update the changelog to document the new codex automation option, including the renamed `codex-token` input for clarity

## Testing
- bun run versions:update
- bun run test:unit

------
https://chatgpt.com/codex/tasks/task_e_6903cef9f9288320a077a93696d39db0