### PR TITLE
feat: resolve #644 - implement wall and rampart upkeep for builder role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here. This changelog now main
 
 ## [Unreleased]
 
+### Added
+
+- **Builder Wall Maintenance**: Builder role now repairs walls and ramparts to configurable target HP thresholds
+  - Added `WALL_TARGET_HP` constant (100,000 HP) for wall repair threshold
+  - Added `RAMPART_TARGET_HP` constant (50,000 HP) for rampart repair threshold
+  - Modified builder repair filter to include walls/ramparts below target HP
+  - Fixes #644: Builder role now maintains defensive structures
+
 ## [0.48.0] - 2025-11-12
 
 ### Changed

--- a/src/runtime/behavior/BehaviorController.ts
+++ b/src/runtime/behavior/BehaviorController.ts
@@ -44,6 +44,10 @@ const STATIONARY_HARVEST_TASK = "stationaryHarvest" as const;
 const HAULER_PICKUP_TASK = "pickup" as const;
 const HAULER_DELIVER_TASK = "haulerDeliver" as const;
 
+// Target HP thresholds for defensive structures
+const WALL_TARGET_HP = 100_000;
+const RAMPART_TARGET_HP = 50_000;
+
 type HarvesterTask = typeof HARVEST_TASK | typeof DELIVER_TASK | typeof UPGRADE_TASK;
 type UpgraderTask = typeof RECHARGE_TASK | typeof UPGRADE_TASK;
 type BuilderTask = typeof BUILDER_GATHER_TASK | typeof BUILDER_BUILD_TASK | typeof BUILDER_MAINTAIN_TASK;
@@ -755,8 +759,12 @@ function runBuilder(creep: ManagedCreep): string {
         return false;
       }
 
-      if (structure.structureType === STRUCTURE_WALL || structure.structureType === STRUCTURE_RAMPART) {
-        return false;
+      if (structure.structureType === STRUCTURE_WALL) {
+        return structure.hits < WALL_TARGET_HP;
+      }
+
+      if (structure.structureType === STRUCTURE_RAMPART) {
+        return structure.hits < RAMPART_TARGET_HP;
       }
 
       return structure.hits < structure.hitsMax;


### PR DESCRIPTION
## Implementation Summary

This PR implements wall and rampart maintenance for the builder role to address issue #644.

### Changes Checklist

- [x] Add configurable target HP thresholds for walls and ramparts
- [x] Update builder repair filter to include walls/ramparts with target HP logic
- [x] Update CHANGELOG.md
- [x] Run linting (passed - no new warnings)
- [x] Run unit tests (passed - 580/580 tests)
- [x] Run build (passed - 745.2kb bundle)
- [x] Validate implementation

### Implementation Details

The current builder role explicitly excluded walls and ramparts from repair operations. This PR:

1. ✅ Added configurable constants for target HP:
   - `WALL_TARGET_HP: 100,000` - walls repaired to 100k HP
   - `RAMPART_TARGET_HP: 50,000` - ramparts repaired to 50k HP

2. ✅ Modified the repair filter in `BehaviorController.ts` (lines 758-766):
   - Walls now repaired when `hits < WALL_TARGET_HP`
   - Ramparts now repaired when `hits < RAMPART_TARGET_HP`
   - Other structures still repaired to `hitsMax`

3. ✅ Maintains builder role behavior:
   - Builders prioritize construction sites first
   - Falls back to repair when no construction sites exist
   - Repairs defensive structures alongside other structures

### Validation Results

- ✅ **Lint**: Passed (no new warnings)
- ✅ **Unit Tests**: 580/580 tests passed
- ✅ **Build**: Passed (745.2kb bundle, 173ms)
- ✅ **Code Review**: Changes verified in source and working as expected

### Key Changes

```typescript
// Added near line 47
const WALL_TARGET_HP = 100_000;
const RAMPART_TARGET_HP = 50_000;

// Modified repair filter (lines 758-766)
if (structure.structureType === STRUCTURE_WALL) {
  return structure.hits < WALL_TARGET_HP;
}

if (structure.structureType === STRUCTURE_RAMPART) {
  return structure.hits < RAMPART_TARGET_HP;
}
```

### Related Issues

- #638 - Energy priority system (walls should have lower priority than critical structures)

Fixes #644